### PR TITLE
chore: Use standard text of the Apache 2.0 license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -6,35 +6,8 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, any and all
-software distributed under the License is distributed on an "AS IS" BASIS,
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
-In addition to the limitations of liability set forth in the License,
-you acknowledge and agree that in no event and under no legal theory,
-whether in tort (including negligence), contract or otherwise, shall
-Centrify Corporation (or any of its affiliates, shareholders, parents,
-subsidiaries, directors, officers, employees, agents, representatives
-or contractors) be liable to you for and you hereby waive, release and
-discharge Centrify Corporation (including its affiliates, shareholders,
-parents, subsidiaries, directors, officers, employees, agents,
-representatives or contractors) from any claims, damages or losses,
-whether direct, indirect, special, incidental, consequential, or punitive,
-whether a third party claim or otherwise, arising or relating in any way
-to this tool (including, without limitation, related to your use or
-inability to use this tool or otherwise related to the License in any way,
-or loss or misuse of any personal data or system data), even if we have been
-advised of the possibility of such damage. While we will endeavor to ensure
-the information contained herein is recent and relevant, Centrify Corporation
-(including any of its affiliates, shareholders, parents, subsidiaries,
-directors, officers, employees, agents, representatives or contractors)
-is not liable for any information that is outdated, incorrect and/or
-irrelevant.  We reserve the right to further remove this tool from
-the public domain at any time and for whatever reason.
-
-When using this tool, we strongly encourage you at a minimum to adopt or
-follow bestindustry practices with regard to information security to prevent
-any data securitybreaches, including storage of personal data, and always
-follow all applicable laws.


### PR DESCRIPTION
This will help pkg.go.dev to determine the license appropriately and show info about this module.

You can check the current state here:
https://pkg.go.dev/github.com/centrify/platform-go-sdk